### PR TITLE
chore: expose all utils for es modules usage

### DIFF
--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -15,7 +15,7 @@ const IGNORES = [
   '__snapshots__',
 ];
 
-it('should export es module of each folder', () => {
+it('should export es module of each Component folder', () => {
   const dirnames = R.without(IGNORES)(fs.readdirSync('./src'));
   dirnames.forEach(name => {
     expect(Modules).toHaveProperty(name);
@@ -66,6 +66,15 @@ it('should export es module of Logo folder', () => {
     'LogoMTK.example.js',
     'LogoMCS.example.js',
   ])(fs.readdirSync('./src/Logo')).map(name => name.replace('.js', ''));
+  dirnames.forEach(name => {
+    expect(Modules).toHaveProperty(name);
+  });
+});
+
+it('should export es module of utils folder', () => {
+  const dirnames = R.without([...IGNORES, 'theme.example.js', 'type.flow.js'])(
+    fs.readdirSync('./src/utils'),
+  ).map(name => name.replace('.js', ''));
   dirnames.forEach(name => {
     expect(Modules).toHaveProperty(name);
   });

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ export * from './ToastContext';
 export * from './KeyHandler';
 export * from './HoCs';
 export * from './Logo';
-export { default as theme } from './utils/theme';
+export * from './utils';
 
 export { default as A } from './A';
 export { default as Avatar } from './Avatar';

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,11 @@
+// @flow
+
+export * from './darken';
+export * from './theme';
+
+export { default as emptyFunction } from './emptyFunction';
+export { default as getCurrentYear } from './getCurrentYear';
+export { default as isString } from './isString';
+export { default as localTimeFormat } from './localTimeFormat';
+export { default as opacity } from './opacity';
+export { default as toMB } from './toMB';

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -47,7 +47,7 @@ const mobile = {
 
 export const fontFamily = `"RionaSans", "Helvetica Neue", "Helvetica", "Arial", "sans-serif"`;
 
-export default {
+export const theme = {
   color: {
     ...gray,
     ...kind,
@@ -57,3 +57,5 @@ export default {
   height,
   mobile,
 };
+
+export default theme;


### PR DESCRIPTION
### Usage

```js
import { emptyFunction, localTimeFormat, kind, theme } from 'mcs-ui';
```